### PR TITLE
Generating scripts failed due to non existing path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@ echo "#!/bin/bash" > "$SCRIPT_DIR/kill_me.sh"
 echo "kill \$(pgrep -f \"python $SCRIPT_DIR/dbus-homemanager.py\")" >> "$SCRIPT_DIR"/kill_me.sh
 
 # Run script
+mkdir -p "$SCRIPT_DIR/service"
 echo "#!/bin/bash" > "$SCRIPT_DIR/service/run"
 echo "python3 $SCRIPT_DIR/dbus-homemanager.py" >> "$SCRIPT_DIR"/service/run
 


### PR DESCRIPTION
The install script didn't work for me on neither a Cerbo GX, nor a Raspberry PI with the Venus OS image.
It was not able to create the scripts in the sub directory. Therefore I added the creation of the directory upfront.